### PR TITLE
[02-performance lab] 접근 방식 변경을 통한 성능 개선

### DIFF
--- a/02-performancelab/kernels.c
+++ b/02-performancelab/kernels.c
@@ -44,11 +44,12 @@ void naive_rotate(int dim, pixel *src, pixel *dst)
 
     for ( i = dim - 1 ; i >= 0 ; --i )
     {
-        for ( j = 0 , iTemp = i ; j < dim ; ++j )
+        for ( j = 0 , iTemp = i ; j < dim ; )
         {
             * dst = src [ iTemp ] ;
             iTemp += dim ;
             ++ dst ;
+            ++j ;
         }
     }
 }

--- a/02-performancelab/kernels.c
+++ b/02-performancelab/kernels.c
@@ -10,13 +10,13 @@
  * Please fill in the following team struct 
  */
 team_t team = {
-    "bovik",              /* Team name */
+    "Soongsil-Developers",              /* Team name */
 
-    "Harry Q. Bovik",     /* First member full name */
-    "bovik@nowhere.edu",  /* First member email address */
+    "kkanggu",                          /* First member full name */
+    "rica742244@gmail.com",             /* First member email address */
 
-    "",                   /* Second member full name (leave blank if none) */
-    ""                    /* Second member email addr (leave blank if none) */
+    "",                                 /* Second member full name (leave blank if none) */
+    ""                                  /* Second member email addr (leave blank if none) */
 };
 
 /***************
@@ -28,16 +28,29 @@ team_t team = {
  ******************************************************/
 
 /* 
- * naive_rotate - The naive baseline version of rotate 
+ * naive_rotate - The naive baseline version of rotate
+ * Edit this to achieve better performance
  */
 char naive_rotate_descr[] = "naive_rotate: Naive baseline implementation";
 void naive_rotate(int dim, pixel *src, pixel *dst) 
 {
-    int i, j;
+//    int i, j;
+//
+//    for (i = 0; i < dim; i++)
+//	for (j = 0; j < dim; j++)
+//	    dst[RIDX(dim-1-j, i, dim)] = src[RIDX(i, j, dim)];
 
-    for (i = 0; i < dim; i++)
-	for (j = 0; j < dim; j++)
-	    dst[RIDX(dim-1-j, i, dim)] = src[RIDX(i, j, dim)];
+    int i , j , iTemp ;
+
+    for ( i = dim - 1 ; i >= 0 ; --i )
+    {
+        for ( j = 0 , iTemp = i ; j < dim ; ++j )
+        {
+            * dst = src [ iTemp ] ;
+            iTemp += dim ;
+            ++ dst ;
+        }
+    }
 }
 
 /* 
@@ -144,16 +157,27 @@ static pixel avg(int dim, int i, int j, pixel *src)
  ******************************************************/
 
 /*
- * naive_smooth - The naive baseline version of smooth 
+ * naive_smooth - The naive baseline version of smooth
+ * Edit this to achieve better performance
  */
 char naive_smooth_descr[] = "naive_smooth: Naive baseline implementation";
 void naive_smooth(int dim, pixel *src, pixel *dst) 
 {
-    int i, j;
+//    int i, j;
+//
+//    for (i = 0; i < dim; i++)
+//	for (j = 0; j < dim; j++)
+//	    dst[RIDX(i, j, dim)] = avg(dim, i, j, src);
 
-    for (i = 0; i < dim; i++)
-	for (j = 0; j < dim; j++)
-	    dst[RIDX(i, j, dim)] = avg(dim, i, j, src);
+    int i , j ;
+
+    for ( i = 0 ; i < dim ; ++i )
+    {
+        for ( j = 0 ; j < dim ; ++j , ++ dst )
+        {
+            * dst = avg ( dim , i , j , src ) ;
+        }
+    }
 }
 
 /*
@@ -165,7 +189,6 @@ void smooth(int dim, pixel *src, pixel *dst)
 {
     naive_smooth(dim, src, dst);
 }
-
 
 /********************************************************************* 
  * register_smooth_functions - Register all of your different versions


### PR DESCRIPTION
### naive_rotate
접근 방식 개선  
기존 프로그램은 src [ 0 to dim * dim - 1 ] -> dst [ ... ] 방식  
이를 dst [ 0 to dim * dim - 1 ] 방식으로 표현할 경우, src [ dim - 1 INC dim , ... dim - dim INC dim ] -> dst [ 0 to dim * dim - 1 ]  
dst는 0부터 탐색하며, src는 dim - 1에서 시작하여 boundary 전까지 dim씩 증가  
dim = 3 일 경우,  src [ 2 , 5 , 8 , 1 , 4 , 7 , 0 , 2 , 5 ] 순서대로 값을 가져와 dst의 앞부터 값이 할당  
병렬 처리를 위하여 값을 가져온 후 변경, 다음 값 할당을 위해 독립적인 명령을 진행  
`Critical Path`의 경우 ```* dst = src [ iTemp ] ;``` 부분으로 예상  

### naive_smooth
접근 방식 개선  
avg 함수 처리에 대해 제대로 이해하지 못 하였기에 이를 섣불리 건드리지 않는 것이 낫다고 판단  
기존 프로그램의 경우 dst [ 0 to dim * dim - 1 ] 순서대로 값 할당  
불필요한 연산 및 배열 탐색 시간을 줄임